### PR TITLE
Remove rust from the cache name

### DIFF
--- a/.github/workflows/build-and-push-container.yml
+++ b/.github/workflows/build-and-push-container.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /nix
-          key: /nixpkgs/${{ matrix.nixpkgs }}/rust/${{ matrix.toolchain.key }}/${{matrix.toolchain.rust.version}}
+          key: /nixpkgs/${{ matrix.nixpkgs }}
       - name: build
         run: just --yes debug=true max_nix_builds=1 rust=${{matrix.toolchain.key}} build
       - name: push


### PR DESCRIPTION
almost none of the build depends on the rust version