### PR TITLE
Regen bump on merge to main

### DIFF
--- a/.github/workflows/build-and-push-container.yml
+++ b/.github/workflows/build-and-push-container.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  workflow_dispatch:
   pull_request:
     branches: "*"
   push:
@@ -133,11 +134,28 @@ jobs:
           done
       - name: step summary
         run: |
-          for f in /tmp/dpdk-sys/builds/*.md; do
-            echo "# $f" >> $GITHUB_STEP_SUMMARY
-            cat "$f" >> $GITHUB_STEP_SUMMARY
-          done
+          echo "# Outdated packages:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/dpdk-sys/builds/env.sysroot.gnu64.release.outdated.md >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Runtime SBOM (gnu64):" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/dpdk-sys/builds/env.sysroot.gnu64.release.runtime.sbom.md >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "# Vuln scan (gnu64):" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/dpdk-sys/builds/env.sysroot.gnu64.release.vulns.triage.md >> $GITHUB_STEP_SUMMARY
+          
+          echo "" >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v4
         with:
-          name: builds-"${{ matrix.rust.toolchain  }}"
+          name: builds-${{ matrix.toolchain.key }}
           path: /tmp/dpdk-sys/builds
+#      - name: Setup tmate session for debug
+#        if: ${{ failure() }}
+#        uses: mxschmitt/action-tmate@v3
+#        timeout-minutes: 30
+#        with:
+#          limit-access-to-actor: true

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -7,11 +7,14 @@
 
 # Production artifacts are produced in a sterile environment (in another CI workflow).
 
-name: bump/versions
+name: "bump/versions"
 on:
   workflow_dispatch:
   schedule:
     - cron: "3 10 * * *"
+  push:
+    branches:
+      - "main"
 
 permissions:
   contents: "write"

--- a/scripts/sbom.sh
+++ b/scripts/sbom.sh
@@ -7,11 +7,14 @@ declare -r sbomnix="github:tiiuae/sbomnix"
 just build-sysroot
 
 declare -r builds="/tmp/dpdk-sys/builds"
+pushd "${builds}"
 declare -r package="env.sysroot"
 
 for libc in "musl64" "gnu64"; do
-  for profile in "debug" "release"; do
-    for dep_type in "runtime" "buildtime"; do
+  # shellcheck disable=SC2043
+  for profile in "release"; do
+    # shellcheck disable=SC2043
+    for dep_type in "runtime"; do
       # shellcheck disable=SC2046,SC2006
       nix run \
         "${sbomnix}#sbomnix" \
@@ -42,15 +45,6 @@ for libc in "musl64" "gnu64"; do
         --verbose=1 \
         $([ "$dep_type" = "buildtime" ] && echo --buildtime) \
         "${builds}/${package}.${libc}.${profile}"
-      # shellcheck disable=SC2046,SC2006
-      nix run \
-        "${sbomnix}#nixgraph" \
-        -- \
-        --out "${builds}/${package}.${libc}.${profile}.${dep_type}.nixgraph.dot" \
-        --depth=99999999 \
-        --verbose=1 \
-        $([ "$dep_type" = "buildtime" ] && echo --buildtime) \
-        "${builds}/${package}.${libc}.${profile}"
     done
     # shellcheck disable=SC2046,SC2006
     nix run \
@@ -59,6 +53,14 @@ for libc in "musl64" "gnu64"; do
       --out "${builds}/${package}.${libc}.${profile}.provenance.json" \
       --verbose=1 \
       --recursive \
+      "${builds}/${package}.${libc}.${profile}"
+    # shellcheck disable=SC2046,SC2006
+    nix run \
+      "${sbomnix}#nixgraph" \
+      -- \
+      --out "${builds}/${package}.${libc}.${profile}.${dep_type}.nixgraph.dot" \
+      --depth=10 \
+      --verbose=1 \
       "${builds}/${package}.${libc}.${profile}"
   done
 done


### PR DESCRIPTION
We requrie a linear commit history so the bump will break regularly without some type of regen function (which this is).

Ideally, we would make this only trigger if the bump/versions branch currently exists, but I'm not sure it is worth the added complexity.

If you don't want to merge bump yet, then just don't.