### PR TITLE
Reduce machine requirements

### DIFF
--- a/nix/flags.nix
+++ b/nix/flags.nix
@@ -1,5 +1,5 @@
 rec {
-  machine = "-mcrc32 -mrtm -msse4 -mssse3 -march=x86-64-v4 -mtune=znver4";
+  machine = "-mcrc32 -mrtm -msse4 -mssse3 -march=x86-64-v3 -mtune=znver4";
   release = rec {
     CFLAGS = " ${machine} -O3 -ggdb3 -flto=thin -Werror=odr -Werror=strict-aliasing -fstack-protector-strong -Qunused-arguments";
     CXXFLAGS = CFLAGS;


### PR DESCRIPTION
x86-64-v4 is still causing CI failures when we get scheduled on old machines.

In the future we should have a more robust system to deal with specific hardware. For now, I'll just lower the requirement.