### PR TITLE
Bump to rdma-core v56.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -133,6 +133,13 @@ rec {
       tinysparql = null;
       util-linux = super.util-linux.override { systemdSupport = false; };
       rdma-core = (fatLto (optimizedBuild super.rdma-core)).overrideAttrs (orig: {
+        version = "56.0";
+        src = self.fetchFromGitHub {
+          owner = "linux-rdma";
+          repo = "rdma-core";
+          rev = "v56.0";
+          hash = "sha256-nzd7BDP72o0TsSTrCGT6HOF7td+3ex4/c68GdjIA6Bc=";
+        };
         outputs = [
           "out"
           "dev"


### PR DESCRIPTION
RDMA core updated and nixpkgs has yet to pull it in.

We want to know about any breakage or regression in rdma-core ASAP so pull it in for testing.