### PR TITLE
fix(redis): temp redis overlay no longer needed

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,10 +38,6 @@ rec {
         mkdir --parent "$out/tmp"
       '';
     };
-    # Temporary hack to get around upstream test failures
-    redis = super.redis.overrideAttrs {
-      doCheck = false;
-    };
 
     graphviz-links = self.stdenv.mkDerivation {
       name = "${project-name}-tmpdir";


### PR DESCRIPTION
Whatever situation was causing redis tests to fail seems to be resolved.  Remove hack.