### PR TITLE
remove cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: "write"
     name: "matrix"
     runs-on:
-      - "lab"
+      - "ubuntu-latest"
     outputs:
       matrix: "${{ steps.matrix.outputs.matrix }}"
     steps:
@@ -195,7 +195,7 @@ jobs:
     name: "summary"
     if: ${{ always() }}
     runs-on:
-      - "lab"
+      - "ubuntu-latest"
     needs:
       - run
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "dtolnay/rust-toolchain@stable"
       - uses: "cargo-bins/cargo-binstall@main"
+      - name: "install sqlite3"
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends sqlite3
       - name: "install whyq"
         run: |
           set -euxo pipefail
@@ -89,9 +94,6 @@ jobs:
 
       - run: |
           cargo binstall --no-confirm just
-
-      - name: "nix cache"
-        uses: "DeterminateSystems/magic-nix-cache-action@main"
 
       - name: "confirm sources"
         run: |

--- a/default.nix
+++ b/default.nix
@@ -62,20 +62,8 @@ rec {
           CXXFLAGS = "${orig.CXXFLAGS or ""} ${flags.CXXFLAGS}";
           LDFLAGS = "${orig.LDFLAGS or ""} ${flags.LDFLAGS}";
         }));
-      fancy.stdenvDynamic = (
-        self.stdenvAdapters.useMoldLinker (
-          if crossEnv == "musl64" then
-            # TODO: It doesn't really make any sense to me that I need
-            # to use pkgsMusl here.
-            # In my mind that is implied by the fact that self is a
-            # crossEnv.
-            self.pkgsMusl.${self.llvmPackagesVersion}.libcxxStdenv
-          else
-            self.llvmPackages.libcxxStdenv
-        )
-      );
+      fancy.stdenvDynamic = (self.stdenvAdapters.useMoldLinker (self.llvmPackages.libcxxStdenv));
       fancy.stdenv = self.stdenvAdapters.makeStaticLibraries fancy.stdenvDynamic;
-      # TODO: consider ways to LTO optimize musl (this one might be a bit tricky)
       buildWithMyFlags = pkg: (buildWithFlags build-flags pkg);
       optimizedBuild =
         pkg:
@@ -148,22 +136,15 @@ rec {
           "-DIOCTL_MODE=write"
           "-DNO_COMPAT_SYMS=1"
         ];
-        patches =
-          (orig.patches or [ ])
-          ++ (
-            if crossEnv == "musl64" then
-              [ ]
-            else
-              [
-                (super.fetchpatch {
-                  # you need to patch rdma-core to build with clang + glibc 2.40.x since glibc 2.40 has improved fortifying
-                  # this function with clang.
-                  name = "fix-for-glibc-2.40.x";
-                  url = "https://git.openembedded.org/meta-openembedded/plain/meta-networking/recipes-support/rdma-core/rdma-core/0001-librdmacm-Use-overloadable-function-attribute-with-c.patch?id=69769ff44ed0572a7b3c769ce3c36f28fff359d1";
-                  sha256 = "sha256-k+T8vSkvljksJabSJ/WRCXTYfbINcW1n0oDQrvFXXGM=";
-                })
-              ]
-          );
+        patches = (orig.patches or [ ]) ++ [
+          (super.fetchpatch {
+            # you need to patch rdma-core to build with clang + glibc 2.40.x since glibc 2.40 has improved fortifying
+            # this function with clang.
+            name = "fix-for-glibc-2.40.x";
+            url = "https://git.openembedded.org/meta-openembedded/plain/meta-networking/recipes-support/rdma-core/rdma-core/0001-librdmacm-Use-overloadable-function-attribute-with-c.patch?id=69769ff44ed0572a7b3c769ce3c36f28fff359d1";
+            sha256 = "sha256-k+T8vSkvljksJabSJ/WRCXTYfbINcW1n0oDQrvFXXGM=";
+          })
+        ];
       });
       iptables = null;
       ethtool = null;
@@ -332,16 +313,6 @@ rec {
               })
             ];
           };
-          pkgsCross.musl64 = import prev.path {
-            overlays = [
-              llvm-overlay
-              helpersOverlay
-              (crossOverlay {
-                build-flags = build-flags.dev;
-                crossEnv = "musl64";
-              })
-            ];
-          };
         })
       ];
     }).pkgsCross;
@@ -360,68 +331,34 @@ rec {
               })
             ];
           };
-          pkgsCross.musl64 = import prev.path {
-            overlays = [
-              llvm-overlay
-              helpersOverlay
-              (crossOverlay {
-                build-flags = build-flags.release;
-                crossEnv = "musl64";
-              })
-            ];
-          };
         })
       ];
     }).pkgsCross;
 
   sysrootPackageListFn =
-    libc: pkgs:
-    with pkgs;
-    (
-      [
-        fancy.libbsd
-        fancy.libbsd.dev
-        dpdk
-        dpdk-wrapper
-        fancy.libmd
-        libmnl
-        libnftnl
-        libnl.out
-        libpcap
-        numactl
-        rdma-core
-      ]
-      ++ (
-        if libc == "gnu64" then
-          [
-            glibc
-            glibc.out
-            libgcc.libgcc
-            glibc.dev
-            glibc.static
-          ]
-        else
-          [ ]
-      )
-      ++ (
-        if libc == "musl64" then
-          [
-            musl.out
-            musl.dev
-          ]
-        else
-          [ ]
-      )
-    );
+    pkgs: with pkgs; [
+      dpdk
+      dpdk-wrapper
+      fancy.libbsd
+      fancy.libbsd.dev
+      fancy.libmd
+      glibc
+      glibc.dev
+      glibc.out
+      glibc.static
+      libgcc.libgcc
+      libmnl
+      libnftnl
+      libnl.out
+      libpcap
+      numactl
+      rdma-core
+    ];
 
   sysrootPackageList = {
     gnu64 = {
-      dev = sysrootPackageListFn "gnu64" pkgs.dev.gnu64;
-      release = sysrootPackageListFn "gnu64" pkgs.release.gnu64;
-    };
-    musl64 = {
-      dev = sysrootPackageListFn "musl64" pkgs.dev.musl64;
-      release = sysrootPackageListFn "musl64" pkgs.release.musl64;
+      dev = sysrootPackageListFn pkgs.dev.gnu64;
+      release = sysrootPackageListFn pkgs.release.gnu64;
     };
   };
 
@@ -476,19 +413,11 @@ rec {
   env = {
     sysroot.gnu64.dev = toolchainPkgs.symlinkJoin {
       name = "${project-name}-env-dev-sysroot-gnu64";
-      paths = sysrootPackageListFn "gnu64" pkgs.dev.gnu64;
+      paths = sysrootPackageListFn pkgs.dev.gnu64;
     };
     sysroot.gnu64.release = toolchainPkgs.symlinkJoin {
       name = "${project-name}-env-release-sysroot-gnu64";
-      paths = sysrootPackageListFn "gnu64" pkgs.release.gnu64;
-    };
-    sysroot.musl64.dev = toolchainPkgs.symlinkJoin {
-      name = "${project-name}-env-dev-sysroot-musl64";
-      paths = sysrootPackageListFn "musl64" pkgs.dev.musl64;
-    };
-    sysroot.musl64.release = toolchainPkgs.symlinkJoin {
-      name = "${project-name}-env-release-sysroot-musl64";
-      paths = sysrootPackageListFn "musl64" pkgs.release.musl64;
+      paths = sysrootPackageListFn pkgs.release.gnu64;
     };
     compile = toolchainPkgs.symlinkJoin {
       name = "${project-name}-env-compile";
@@ -501,69 +430,58 @@ rec {
   };
 
   sysrootFn =
-    libc: profile:
-    let
-      libcShortName = (if libc == "gnu64" then "gnu" else "musl");
-    in
+    profile:
     toolchainPkgs.stdenv.mkDerivation {
-      name = "${project-name}-sysroot.${libc}.${profile}";
+      name = "${project-name}-sysroot.gnu64.${profile}";
       nativeBuildInputs = [ toolchainPkgs.rsync ];
       src = null;
       dontUnpack = true;
       installPhase = ''
-        mkdir --parent "$out/sysroot/x86_64-unknown-linux-${libcShortName}/${profile}/"{lib,include}
+        mkdir --parent "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/"{lib,include}
         rsync -rLhP \
-          "${env.sysroot.${libc}.${profile}}/lib/" \
-          "$out/sysroot/x86_64-unknown-linux-${libcShortName}/${profile}/lib/"
+          "${env.sysroot.gnu64.${profile}}/lib/" \
+          "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/lib/"
         rsync -rLhP \
-          "${env.sysroot.${libc}.${profile}}/include/" \
-          "$out/sysroot/x86_64-unknown-linux-${libcShortName}/${profile}/include/"
+          "${env.sysroot.gnu64.${profile}}/include/" \
+          "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/include/"
       '';
       # Rust can't decided if the profile is called dev or debug so we need a fixup
       postFixup =
         (
           if profile == "dev" then
             ''
-              ln -s dev $out/sysroot/x86_64-unknown-linux-${libcShortName}/debug
+              ln -s dev $out/sysroot/x86_64-unknown-linux-gnu64/debug
             ''
           else
             ""
         )
         + (
-          if libc == "gnu64" then
-            # libm.a file contains a GROUP instruction which contains absolute paths to /nix
-            # and those paths are not preserved by the rsync commands.
-            ''
-              export lib="$out/sysroot/x86_64-unknown-linux-${libcShortName}/${profile}/lib"
-              cd $lib
-              cat > libm.a <<EOF
-              OUTPUT_FORMAT(elf64-x86-64)
-              GROUP ( libm-${pkgs.dev.gnu64.glibc.version}.a libmvec.a )
-              EOF
-              cat > libm.so <<EOF
-              OUTPUT_FORMAT(elf64-x86-64)
-              GROUP ( libm.so.6 AS_NEEDED ( libmvec.so.1 ) )
-              EOF
-              cat > libc.so <<EOF
-              OUTPUT_FORMAT(elf64-x86-64)
-              GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ld-linux-x86-64.so.2 ) )
-              EOF
-            ''
-          else
-            ""
-        );
+          # libm.a file contains a GROUP instruction which contains absolute paths to /nix
+          # and those paths are not preserved by the rsync commands.
+          ''
+            export lib="$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/lib"
+            cd $lib
+            cat > libm.a <<EOF
+            OUTPUT_FORMAT(elf64-x86-64)
+            GROUP ( libm-${pkgs.dev.gnu64.glibc.version}.a libmvec.a )
+            EOF
+            cat > libm.so <<EOF
+            OUTPUT_FORMAT(elf64-x86-64)
+            GROUP ( libm.so.6 AS_NEEDED ( libmvec.so.1 ) )
+            EOF
+            cat > libc.so <<EOF
+            OUTPUT_FORMAT(elf64-x86-64)
+            GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ld-linux-x86-64.so.2 ) )
+            EOF
+          '');
     };
 
-  sysroot.gnu64.dev = sysrootFn "gnu64" "dev";
-  sysroot.gnu64.release = sysrootFn "gnu64" "release";
-  sysroot.musl64.dev = sysrootFn "musl64" "dev";
-  sysroot.musl64.release = sysrootFn "musl64" "release";
+  sysroot.gnu64.dev = sysrootFn "dev";
+  sysroot.gnu64.release = sysrootFn "release";
 
   sysroots = with sysroot; [
     gnu64.dev
     gnu64.release
-    musl64.dev
-    musl64.release
   ];
 
   maxLayers = 120;
@@ -622,7 +540,7 @@ rec {
         pkgs.release.gnu64.glibc.dev
         pkgs.dev.gnu64.glibc.out
         pkgs.release.gnu64.glibc.out
-      ] ++ (sysroots);
+      ] ++ sysroots;
       inherit maxLayers;
     };
     doc-env = toolchainPkgs.dockerTools.buildLayeredImage {

--- a/justfile
+++ b/justfile
@@ -120,8 +120,6 @@ build-sysroot: \
   (_nix_build "sysroots") \
   (_nix_build "env.sysroot.gnu64.dev") \
   (_nix_build "env.sysroot.gnu64.release") \
-  (_nix_build "env.sysroot.musl64.dev") \
-  (_nix_build "env.sysroot.musl64.release") \
   (_nix_build "sysroot")
 
 # Build doc env packages

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -38,7 +38,6 @@
       profile = "default";
       targets = [
         "x86_64-unknown-linux-gnu"
-        "x86_64-unknown-linux-musl"
       ];
       extensions = [
         "cargo"

--- a/nix/versions.nix.template
+++ b/nix/versions.nix.template
@@ -38,7 +38,6 @@
       profile = "default";
       targets = [
         "x86_64-unknown-linux-gnu"
-        "x86_64-unknown-linux-musl"
       ];
       extensions = [
         "cargo"

--- a/scripts/estimate-jobs.sh
+++ b/scripts/estimate-jobs.sh
@@ -12,7 +12,7 @@ declare -ri free_memory;
 
 # guess the worst case memory load per core for build (GiB)
 declare max_mem_per_core_guess;
-max_mem_per_core_guess=7;
+max_mem_per_core_guess=10;
 declare -ri max_mem_per_core_guess;
 
 # guess the max number of cores we can safely use

--- a/scripts/sbom.sh
+++ b/scripts/sbom.sh
@@ -24,7 +24,7 @@ trap cleanup EXIT
 declare summary="${builds}/${package}.summary.md"
 truncate --size 0 "${summary}"
 
-for libc in "gnu64" "musl64"; do
+for libc in "gnu64"; do
   pushd "$(mktemp -d)" && cleanup_cmds+=("rm -rf $(pwd)")
   nix run \
     "${sbomnix}#sbomnix" \


### PR DESCRIPTION
It turns out that we _can't_ use the cache when we have a deep rebuild in place because we drive the CI machines out of disc space (or at least that is the working theory).

Fortunately, this is a temporary condition and we can cache again after this libxml2 test is over.

Technically, we can call the test over now since I don't think we have a lot left to learn from it anyway.

The things we did learn are

1. our prior CI was not equipped do to a deep rebuild of our full dependency tree.  If there were a serious security issue or major bug which we needed to react to, this would have been a notable problem for us.
2. removing the musl sysroot functionally halved our cache and build time requirements, and even then we didn't have enough disk space on the runners to make the deep rebuild work.
3. removing musl _without_ the deep rebuild keeps our build times _way_ down (because we no longer need to compile llvm in that case).

Combined, I would say that we can merge this and just deal with the long build until libxml2 gets updated in nixpkgs; likely within the next two or three weeks.
The fix is already in staging, it will need to graduate to staging-next and then will hit the unstable channel (which is what we consume).

The alternative is to revert [the commit which introduced the deep rebuild](https://github.com/githedgehog/dpdk-sys/commit/5b729375fd2bd3d7703e7e634d59e34f89351e9b) and call the experiment over.

The libxml2 fix addresses a problem

1. used only as a build time dependency,
2. which is over a decade old.

Given that, and the fact that we aren't in production yet, I think it is reasonable to merge this and then revert the commit in question (which should bring our build time [back down to the 20-45 minute range](https://github.com/githedgehog/dpdk-sys/actions/runs/13475889266)).
