### PR TITLE
fix(sysroot): incorrect sysroot path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    target-branch: "main"
+    commit-message:
+      prefix: "bump(github-actions):"
+    directories:
+      - "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "automated"
+      - "dependencies"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,11 +36,6 @@ jobs:
       - uses: "actions/checkout@v4"
       - uses: "dtolnay/rust-toolchain@stable"
       - uses: "cargo-bins/cargo-binstall@main"
-      - name: "install sqlite3"
-        run: |
-          set -euxo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends sqlite3
       - name: "install whyq"
         run: |
           set -euxo pipefail

--- a/default.nix
+++ b/default.nix
@@ -425,20 +425,20 @@ rec {
       src = null;
       dontUnpack = true;
       installPhase = ''
-        mkdir --parent "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/"{lib,include}
+        mkdir --parent "$out/sysroot/x86_64-unknown-linux-gnu/${profile}/"{lib,include}
         rsync -rLhP \
           "${env.sysroot.gnu64.${profile}}/lib/" \
-          "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/lib/"
+          "$out/sysroot/x86_64-unknown-linux-gnu/${profile}/lib/"
         rsync -rLhP \
           "${env.sysroot.gnu64.${profile}}/include/" \
-          "$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/include/"
+          "$out/sysroot/x86_64-unknown-linux-gnu/${profile}/include/"
       '';
       # Rust can't decided if the profile is called dev or debug so we need a fixup
       postFixup =
         (
           if profile == "dev" then
             ''
-              ln -s dev $out/sysroot/x86_64-unknown-linux-gnu64/debug
+              ln -s dev $out/sysroot/x86_64-unknown-linux-gnu/debug
             ''
           else
             ""
@@ -447,7 +447,7 @@ rec {
           # libm.a file contains a GROUP instruction which contains absolute paths to /nix
           # and those paths are not preserved by the rsync commands.
           ''
-            export lib="$out/sysroot/x86_64-unknown-linux-gnu64/${profile}/lib"
+            export lib="$out/sysroot/x86_64-unknown-linux-gnu/${profile}/lib"
             cd $lib
             cat > libm.a <<EOF
             OUTPUT_FORMAT(elf64-x86-64)


### PR DESCRIPTION
Back in [cb0ff0d18a7eb69bded84cc6f0819e2043eea6ef](https://github.com/githedgehog/dpdk-sys/commit/cb0ff0d18a7eb69bded84cc6f0819e2043eea6ef) I typoed this sysroot path and now [dataplane #285](https://github.com/githedgehog/dataplane/pull/285) is stalled waiting for this fix.

Sorry folks ¯\\\_(ツ)_/¯