### PR TITLE
log kube node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,10 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
+      - name: "log KUBE_NODE"
+        run: |
+          echo "$KUBE_NODE"
+
       - uses: "actions/checkout@v4"
 
       - name: "install nix"


### PR DESCRIPTION
We are getting surprisingly frequent build stalls in CI and I'm concerned that the lab machines are flaking out.

I'm following Sergei Lukianov's advice and adding a log of the CI machine's KUBE_NODE env var to help debug.