### PR TITLE
fix(build): Update to the latest rust 1.86.0-beta.6

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -4,7 +4,7 @@
 # (to the point of needing automation to keep up to date).
 env:
   rust_pins:
-    beta: &rust_beta "1.86.0-beta.5"
+    beta: &rust_beta "1.86.0-beta.6"
   llvm_for_rust_pins:
     stable: &llvm_stable "19"
   nixpkgs:


### PR DESCRIPTION
dataplane is seeing test failures that may be related to rust beta.2 bump rust version to beta.6 to see if doctest in sterile CI error is fixed for the pipeline crate on dataplane PR #360