### PR TITLE
Revert "feat(default.nix): Rust to beta for RFC feature(trait-upcasting)"

### DIFF
--- a/builds.template.yml
+++ b/builds.template.yml
@@ -4,9 +4,9 @@
 # (to the point of needing automation to keep up to date).
 env:
   rust_pins:
-    beta: &rust_beta "${RUST_BETA_PIN}"
+    stable: &rust_stable "${RUST_STABLE_PIN}"
   llvm_for_rust_pins:
-    stable: &llvm_stable "${RUST_BETA_PIN_LLVM}"
+    stable: &llvm_stable "${RUST_STABLE_PIN_LLVM}"
   nixpkgs:
     unstable: &nixpkgs_unstable "${NIXPKGS_COMMIT}"
   just:
@@ -14,12 +14,13 @@ env:
 # matrix describes the test structure which I expect to be relatively stable.
 matrix:
   toolchain:
-    - &default
-      key: "beta"
+    - # pinned stable
+      &default
+      key: "stable"
       llvm: *llvm_stable
       rust:
-        channel: "beta"
-        version: *rust_beta
+        channel: "stable"
+        version: *rust_stable
       sysroot:
         profile:
           - "release"

--- a/builds.yml
+++ b/builds.yml
@@ -4,7 +4,7 @@
 # (to the point of needing automation to keep up to date).
 env:
   rust_pins:
-    beta: &rust_beta "1.86.0-beta.7"
+    stable: &rust_stable "1.86.0"
   llvm_for_rust_pins:
     stable: &llvm_stable "19"
   nixpkgs:
@@ -14,12 +14,13 @@ env:
 # matrix describes the test structure which I expect to be relatively stable.
 matrix:
   toolchain:
-    - &default
-      key: "beta"
+    - # pinned stable
+      &default
+      key: "stable"
       llvm: *llvm_stable
       rust:
-        channel: "beta"
-        version: *rust_beta
+        channel: "stable"
+        version: *rust_stable
       sysroot:
         profile:
           - "release"

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 {
-  rust-channel ? "beta",
+  rust-channel ? "stable",
   build-flags ? import ./nix/flags.nix,
   versions ? import ./nix/versions.nix,
   image-tag ? "latest",

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ debug := "false"
 # These versions are pinned by the `./nix/versions.nix`
 # file (which is managed by `./scripts/bump.sh`)
 
-rust := "beta"
+rust := "stable"
 container_repo := "ghcr.io/githedgehog/dpdk-sys"
 
 # This is the maximum number of builds nix will start at a time.

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -31,9 +31,9 @@
     };
   };
   rust = {
-    beta = {
-      channel = "beta";
-      version = "latest";
+    stable = {
+      channel = "stable";
+      version = "1.86.0";
       llvm = "19";
       profile = "default";
       targets = [

--- a/nix/versions.nix.template
+++ b/nix/versions.nix.template
@@ -31,10 +31,10 @@
     };
   };
   rust = {
-    beta = {
-      channel = "beta";
-      version = "latest";
-      llvm = "$RUST_BETA_PIN_LLVM";
+    stable = {
+      channel = "stable";
+      version = "$RUST_STABLE_PIN";
+      llvm = "$RUST_STABLE_PIN_LLVM";
       profile = "default";
       targets = [
         "x86_64-unknown-linux-gnu"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -98,14 +98,14 @@ nix_multi_hash NIXPKGS_ARCHIVE "${nixpkgs_repo}/${NIXPKGS_COMMIT}.tar.gz" "${NIX
 pushd "${project_dir}"
 
 rustup update
-rustup toolchain install "beta"
+rustup toolchain install "stable"
 rustup update
 
-declare RUST_BETA_PIN RUST_BETA_PIN_LLVM
-RUST_BETA_PIN="$(rustc "+beta" -vV | grep 'release:' | awk '{print $NF}')"
-RUST_BETA_PIN_LLVM="$(rustc "+beta" -vV | grep 'LLVM version:' | awk '{print $NF}' | sed 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+/\1/')"
-declare -rx RUST_BETA_PIN
-declare -rx RUST_BETA_PIN_LLVM
+declare RUST_STABLE_PIN RUST_STABLE_PIN_LLVM
+RUST_STABLE_PIN="$(rustc "+stable" -vV | grep 'release:' | awk '{print $NF}')"
+RUST_STABLE_PIN_LLVM="$(rustc "+stable" -vV | grep 'LLVM version:' | awk '{print $NF}' | sed 's/\([0-9]\+\)\.[0-9]\+\.[0-9]\+/\1/')"
+declare -rx RUST_STABLE_PIN
+declare -rx RUST_STABLE_PIN_LLVM
 
 declare JUST_STABLE_PIN
 JUST_STABLE_PIN="$(just --version | grep '^just ' | awk '{print $NF}')"


### PR DESCRIPTION
This reverts commit 08722ab2fb04beb5c023027d610111e910dbc890.

Now that Rust v1.86.0 is out with the features we wanted for the dataplane, let's use the stable toolchain as a default again.

Note: I dropped the Nix versions hash changes, I think they were unrelated to the change of toolchain and I don't know how to refresh them anyway. I'll leave it to the GitHub workflow.
