### PR TITLE
Fix CI + minor improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,9 +102,12 @@ jobs:
         run: |
           ./scripts/confirm-sources.sh
 
-      - name: "build + push"
+      - name: "build + push (debug)"
         run: |
           sudo --preserve-env just --yes profile=debug debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
+
+      - name: "build + push (release)"
+        run: |
           sudo --preserve-env just --yes profile=release debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
 
       - name: "Install SBOM generator dependencies"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,13 +104,13 @@ jobs:
 
       - name: "build + push"
         run: |
-          just --yes profile=debug debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
-          just --yes profile=release debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
+          sudo --preserve-env just --yes profile=debug debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
+          sudo --preserve-env just --yes profile=release debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
 
       - name: "Install SBOM generator dependencies"
         run: |
           for f in /tmp/dpdk-sys/builds/*; do
-            [ -h "$f" ] && rm "$f"
+            [ -h "$f" ] && sudo --preserve-env rm "$f"
           done
           cargo binstall --no-confirm csview
           sudo apt-get update
@@ -118,7 +118,7 @@ jobs:
 
       - name: "generate SBOM"
         run: |
-          ./scripts/sbom.sh
+          sudo --preserve-env ./scripts/sbom.sh
 
       - name: "step summary"
         continue-on-error: true # might fail due to $GITHUB_STEP_SUMMARY size limit of 1MB
@@ -128,7 +128,7 @@ jobs:
       - name: "remove links from /tmp/dpdk-sys/builds"
         run: |
           for f in /tmp/dpdk-sys/builds/*; do
-              [ -h "$f" ] && rm "$f"
+              [ -h "$f" ] && sudo rm "$f"
           done
 
       - uses: "actions/upload-artifact@v4"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: "build + push (debug)"
         run: |
-          sudo --preserve-env just --yes profile=debug debug=true max_nix_builds=1 rust="${{ matrix.toolchain.key }}" push
+          sudo --preserve-env just --yes profile=debug debug=true max_nix_builds=1 cores=$(nproc) rust="${{ matrix.toolchain.key }}" push
 
       - name: "build + push (release)"
         run: |

--- a/default.nix
+++ b/default.nix
@@ -637,7 +637,7 @@ rec {
       name = "${contianer-repo}/debug-env";
       tag = "${image-tag}";
       contents = (with toolchainPkgs; [
-        bash
+        bashInteractive
         coreutils
         curl
         ethtool

--- a/default.nix
+++ b/default.nix
@@ -569,6 +569,14 @@ rec {
       installPhase = ''
         mkdir --parent "$out/sysroot/x86_64-unknown-linux-gnu/${profile}/"{lib,include}
         rsync -rLhP \
+          --exclude '- *.so' \
+          --exclude '- *.so.*' \
+          --exclude '- *.la' \
+          --exclude '- *.pc' \
+          --exclude '- *.la' \
+          --include 'libc.so*' \
+          --include 'libm.so*' \
+          --include 'libgcc_s.so*' \
           "${env.sysroot.gnu64.${profile}}/lib/" \
           "$out/sysroot/x86_64-unknown-linux-gnu/${profile}/lib/"
         rsync -rLhP \

--- a/default.nix
+++ b/default.nix
@@ -640,15 +640,18 @@ rec {
         bashInteractive
         coreutils
         curl
+        debianutils
         ethtool
         gawk
         gdb
         gnugrep
         gnused
         iproute2
+        iptables
         jq
         less
         nano
+        procps
         rr
         strace
         tcpdump

--- a/justfile
+++ b/justfile
@@ -177,31 +177,60 @@ _build-container target container-name: (_nix_build ("container." + target))
 # Build and tag the compile-env container
 build-compile-env-container: build-sysroot (_build-container "compile-env" _compile_env_container_name)
 
+# build and push the compile-env container
+[script]
+push-compile-env-container: build-compile-env-container
+    {{ _just_debug_ }}
+    docker push "{{ _compile_env_container_name }}:{{ _slug }}"
+
 # Build and tag the frr container
 build-frr-container: (_build-container "frr-" + profile _frr_container_name)
+
+# build and push the frr container
+[script]
+push-frr-container: build-frr-container
+    {{ _just_debug_ }}
+    docker push "{{ _frr_container_name }}:{{ _slug }}"
 
 # Build and tag the libc container
 build-libc-container: (_build-container "libc-env" _libc_container_name)
 
+# build and push the libc container
+push-libc-container: build-libc-container
+    {{ _just_debug_ }}
+
 # Build and tag the libc container
 build-debug-container: (_build-container "debug-env" _debug_container_name)
 
+# build and push the libc container
+[script]
+push-debug-container: build-debug-container
+    {{ _just_debug_ }}
+    docker push "{{ _libc_container_name }}:{{ _slug }}"
+
 # Build and tag the libc container
-build-mstflint-container: (_build-container "mstflint" _mstflint_container_name)
+build-mstflint-container: (_build-container "mstflint-" + profile _mstflint_container_name)
+
+# build and push the libc container
+[script]
+push-mstflint-container: build-mstflint-container
+    {{ _just_debug_ }}
+    docker push "{{ _mstflint_container_name }}:{{ _slug }}"
 
 # Build the sysroot, and compile-env containers
-build: build-sysroot build-libc-container build-compile-env-container build-frr-container build-debug-container
+build: \
+  build-libc-container \
+  build-debug-container \
+  build-compile-env-container \
+  build-frr-container
 
 # Push the containers to the container registry
 [script]
-push: build
-    {{ _just_debug_ }}
-    docker push "{{ _compile_env_container_name }}:{{ _slug }}"
-    docker push "{{ _frr_container_name }}:{{ _slug }}"
-    docker push "{{ _libc_container_name }}:{{ _slug }}"
-    docker push "{{ _debug_container_name }}:{{ _slug }}"
-    # Temporary comment to reduce build times
-    # docker push "{{ _mstflint_container_name }}:{{ _slug }}"
+push: \
+  push-libc-container \
+  push-debug-container \
+  push-compile-env-container \
+  push-frr-container
 
 # Delete all the old generations of the nix store and run the garbage collector
 [script]

--- a/nix/flags.nix
+++ b/nix/flags.nix
@@ -3,7 +3,7 @@ rec {
   release = rec {
     CFLAGS = " ${machine} -O3 -ggdb3 -flto=thin -Werror=odr -Werror=strict-aliasing -fstack-protector-strong -Qunused-arguments";
     CXXFLAGS = CFLAGS;
-    LDFLAGS = "-flto=thin -fuse-ld=lld -Wl,-O3 -Wl,-z,relro,-z,now -Wl,--thinlto-jobs=1 -Qunused-arguments";
+    LDFLAGS = "-flto=thin -fuse-ld=lld -Wl,-O3 -Wl,-z,relro,-z,now -Wl,--thinlto-jobs=6 -Qunused-arguments";
   };
 
   debug = rec {

--- a/scripts/estimate-jobs.sh
+++ b/scripts/estimate-jobs.sh
@@ -12,7 +12,7 @@ declare -ri free_memory;
 
 # guess the worst case memory load per core for build (GiB)
 declare max_mem_per_core_guess;
-max_mem_per_core_guess=10;
+max_mem_per_core_guess=3;
 declare -ri max_mem_per_core_guess;
 
 # guess the max number of cores we can safely use


### PR DESCRIPTION
The new github runners have broken our CI, but only very slightly.

* I fixed it in this PR.  
* I added some debugging improvments to make the build a little easier to take apart if needed
* I found that the new runners are much less prone to OOM killing our builds, so I expanded the available parallelism in the build significantly.  This reduced the build time by quite a lot (~30-40minutes -> ~23minutes).
* I stapled on minor improvements I made for @Fredi-raspall's debug env while I was at it.