### PR TITLE
fix: once again, fix frr link

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN find / -name '*.h' -exec rm -f {} \;
 RUN mkdir -p /run/frr/hh /var/run/frr/hh
 RUN chown -R frr:frr /run/frr
 RUN chown -R frr:frr /var/run/frr
-#RUN ln -s / $(< /the-path-to-frr) && rm /the-path-to-frr
+# hack to deal with /usr/bin/python3 path in frr
+RUN ln -s / /usr
 FROM scratch AS frr-release
 COPY --from=frr-base / /
 CMD ["/libexec/frr/docker-start"]


### PR DESCRIPTION
FRR's python scripts do not get their shebang lines properly patched.

They are also looking under /usr/bin/python3 for python.

The easiest fix is to symlink /usr to / rather than trying to fight where nix keeps its symlinks.