### PR TITLE
fix: clear frr nexthops at start

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -555,6 +555,8 @@
           findutils
           frr-agent
           frr-config
+          iproute2
+          jq
           libgccjit
           pkgs.${profile}.gnu64.frr
           prometheus-frr-exporter

--- a/nix/frr-config/config/libexec/frr/docker-start
+++ b/nix/frr-config/config/libexec/frr/docker-start
@@ -2,6 +2,10 @@
 
 source /libexec/frr/frrcommon.sh
 
+ip -j -d nexthop show | \
+  jq --raw-output '.[] | select(.protocol="zebra").id' | \
+  while read -r id; do ip nexthop del id "${id}"; done
+
 /libexec/frr/watchfrr $(daemon_list) &
 
 /bin/frr-agent "${@}" &


### PR DESCRIPTION
On restart, FRR is learning routes that the prior incarnation of FRR installed into the kernel.

This is undermining our ability to restart the dataplane.

Clean up those routes on frr start so that we can avoid this issue in the future.