### PR TITLE
ci: add optional vlab job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
 
       - uses: "actions/checkout@v4"
         with:
+          # make sure to update the vlab prebuild script if changing it
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "install nix"
@@ -200,6 +201,48 @@ jobs:
         with:
           limit-access-to-actor: true
 
+  vlab:
+    needs:
+      - run
+
+    name: "${{ matrix.hybrid && 'hlab' || 'vlab' }}-${{ matrix.fabricmode == 'spine-leaf' && 'sl' || 'cc' }}-${{ matrix.gateway && 'gw-' || '' }}${{ matrix.includeonie && 'onie-' || '' }}${{ matrix.buildmode }}-${{ matrix.vpcmode }}"
+
+    uses: githedgehog/fabricator/.github/workflows/run-vlab.yaml@master
+    with:
+      skip: ${{ matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+hlab') || !matrix.hybrid && !contains(github.event.pull_request.labels.*.name, 'ci:+vlab') }}
+      fabricatorref: master
+      prebuild: "just bump frr ${{ github.event.pull_request.head.sha }}.debug"
+      fabricmode: ${{ matrix.fabricmode }}
+      gateway: ${{ matrix.gateway }}
+      includeonie: ${{ matrix.includeonie }}
+      buildmode: ${{ matrix.buildmode }}
+      vpcmode: ${{ matrix.vpcmode }}
+      releasetest: ${{ contains(github.event.pull_request.labels.*.name, 'ci:+release') }}
+      hybrid: ${{ matrix.hybrid }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        fabricmode:
+          - spine-leaf
+        gateway:
+          - true
+        includeonie:
+          - false
+        buildmode:
+          - iso
+        vpcmode:
+          - l2vni
+          - l3vni
+        hybrid:
+          - false
+        include:
+          - fabricmode: spine-leaf
+            gateway: true
+            includeonie: false
+            buildmode: iso
+            vpcmode: l2vni
+            hybrid: true
 
   summary:
     name: "summary"
@@ -208,9 +251,15 @@ jobs:
       - "ubuntu-latest"
     needs:
       - run
+      - vlab
     steps:
       - name: "Flag any build matrix failures"
-        if: ${{ needs.run.result != 'success' }}
+        if: ${{ needs.run.result != 'success' && needs.run.result != 'skipped' }}
+        run: |
+          >&2 echo "A critical step failed!"
+          exit 1
+      - name: "Flag any vlab matrix failures"
+        if: ${{ needs.vlab.result != 'success' && needs.vlab.result != 'skipped' }}
         run: |
           >&2 echo "A critical step failed!"
           exit 1


### PR DESCRIPTION
Somewaht matching what we agreed on the dataplane. The main goal here is to be able to check FRR images earlier.
No new jobs will run by default as we don't have stable, meaningful tests for the frr.

Use the following labels to enable some jobs/tests:

ci:+vlab - enable fully virtual VLAB jobs (2 of them - one with l2vni and one with l3vni vpcs)
ci:+hlab - enable hubrid VLAB job (using env with physical switches and control/gw/servers in VMs - just a single run with l2vni)
ci:+release - enable release tests on all enabled VLAB jobs (controlled by 2 prev labels) - it runs all the tests we have and takes about 1h on vlab and 3.5 hours on hlab, doesn't contain ANY jobs for the gw yet

You would need to close and reopen PR after adding labels for them to take effect.

Same as in the dataplane repo it relies on image built in a previous steps.

Fixes #144 